### PR TITLE
Added Decimal.zero, Decimal.one and .inverse

### DIFF
--- a/lib/decimal.dart
+++ b/lib/decimal.dart
@@ -25,6 +25,9 @@ class Decimal implements Comparable<Decimal> {
 
   Decimal._fromRational(this._rational);
 
+  static Decimal zero = Decimal.fromInt(0);
+  static Decimal one = Decimal.fromInt(1);
+
   static Decimal tryParse(String value) {
     try {
       return Decimal.parse(value);
@@ -32,6 +35,9 @@ class Decimal implements Comparable<Decimal> {
       return null;
     }
   }
+
+  Decimal get inverse => Decimal._fromRational(
+      Rational(_rational.denominator, _rational.numerator));
 
   Rational _rational;
 

--- a/test/decimal_test.dart
+++ b/test/decimal_test.dart
@@ -268,4 +268,13 @@ void main() {
     expect(
         Decimal.parse('21.962962546543768').toString(), '21.962962546543768');
   });
+  test("zero", () {
+    expect(Decimal.zero, Decimal.fromInt(0));
+  });
+  test("one", () {
+    expect(Decimal.one, Decimal.fromInt(1));
+  });
+  test("inverse", () {
+    expect(Decimal.tryParse('0.5').inverse, Decimal.fromInt(2));
+  });
 }


### PR DESCRIPTION
`Decimal.zero` and `Decimal.one` are useful for being identity elements of addition and multiplication respectively, are commonly used and imho deserve a place in Decimal.

`.inverse` should be more efficient than doing `Decimal.one / decimal`.