### PR TITLE
Add extension on num to convert to Decimal

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,10 @@ import 'package:decimal/decimal.dart';
 
 * Start computing using `Decimal.parse('1.23')`.
 
-_Hint_ : To make your code shorter you can define a shortcut for Decimal.parse :
-
+* You can also use `toDecimal()` extension on `num` type:
 ```dart
-final d = (String s) => Decimal.parse(s);
-d('0.2') + d('0.1'); // => 0.3
+final pointOne = 0.1.toDecimal();
+final d = (0.2 + pointOne).toDecimal();
 ```
 
 ## Formatting with intl

--- a/lib/decimal.dart
+++ b/lib/decimal.dart
@@ -208,3 +208,8 @@ class Decimal implements Comparable<Decimal> {
   /// Returns [one] if the [exponent] equals `0`.
   Decimal pow(int exponent) => Decimal._fromRational(_rational.pow(exponent));
 }
+
+extension NumToDecimal on num {
+  /// This number as [Decimal]
+  Decimal toDecimal() => Decimal.parse(toString());
+}


### PR DESCRIPTION
To make usage of Decimal more convenient adds an extension on num type
with 'toDecimal()' function that converts current number value to the
Decimal value, this it is possible to write code as:

```dart
  final myDecimal = 3.141592.toDecimal();
```

Of course the `package:decimal/decimal.dart` needs to be imported in
order to use this extension.

Initially I wanted to add an `decimal` getter. But since there are no
getters like that on num type, instead `toInt()` and `toDouble()`
functions are used. Therefore this is also `toDecimal()`.