### PR TITLE
fixed Bug with divide to 0

### DIFF
--- a/lib/decimal.dart
+++ b/lib/decimal.dart
@@ -77,6 +77,7 @@ class Decimal implements Comparable<Decimal> {
   /// Returns a [String] representation of `this`.
   @override
   String toString() {
+    if (_rational.denominator == BigInt.zero) return 'Undefined';
     if (_rational.isInteger) return _rational.toString();
     var value = toStringAsFixed(scale);
     while (


### PR DESCRIPTION
Maybe give rational a boolean for isUndefined? or change the return type of operator/(Decimal) to Decimal with an exception thrown if divide by 0