### PR TITLE
Introduce logical operators to DecimalIntl to support intl 0.18.0

### DIFF
--- a/lib/intl.dart
+++ b/lib/intl.dart
@@ -17,6 +17,7 @@ import 'package:rational/rational.dart';
 
 class DecimalIntl {
   DecimalIntl(Decimal decimal) : this._rational(decimal.toRational());
+
   DecimalIntl._rational(this._rational);
 
   factory DecimalIntl._(dynamic number) {
@@ -54,6 +55,16 @@ class DecimalIntl {
 
   DecimalIntl operator /(dynamic other) =>
       DecimalIntl._(_rational / DecimalIntl._(other)._rational);
+
+  bool operator <(dynamic other) => _rational < DecimalIntl._(other)._rational;
+
+  bool operator <=(dynamic other) =>
+      _rational <= DecimalIntl._(other)._rational;
+
+  bool operator >(dynamic other) => _rational > DecimalIntl._(other)._rational;
+
+  bool operator >=(dynamic other) =>
+      _rational >= DecimalIntl._(other)._rational;
 
   DecimalIntl remainder(dynamic other) =>
       DecimalIntl._(_rational.remainder(DecimalIntl._(other)._rational));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,6 @@ dependencies:
 
 dev_dependencies:
   expector: ^0.1.2
-  intl: ^0.17.0
+  intl: ^0.18.0
   lints: ^2.0.0
   test: ^1.17.2

--- a/test/intl_test.dart
+++ b/test/intl_test.dart
@@ -18,7 +18,7 @@ import 'package:expector/expector.dart';
 import 'package:intl/intl.dart';
 import 'package:test/test.dart' show test;
 
-Decimal dec(String value) => Decimal.parse(value);
+DecimalIntl decIntl(String value) => DecimalIntl(Decimal.parse(value));
 
 void main() {
   test('Number.format output the same result as with double', () {
@@ -38,5 +38,35 @@ void main() {
             .equals(format.format(double.parse(number)));
       }
     }
+  });
+
+  test('Number.compactCurrency output the correct results', () {
+    final format = NumberFormat.compactCurrency(locale: 'en-US', symbol: '');
+    expectThat(format.format(decIntl('1000000000'))).equals('1B');
+  });
+
+  test('operator <(DecimalIntl other)', () {
+    expectThat(decIntl('1') < decIntl('1')).isFalse;
+    expectThat(decIntl('1') < decIntl('1.0')).isFalse;
+    expectThat(decIntl('1') < decIntl('1.1')).isTrue;
+    expectThat(decIntl('1') < decIntl('0.9')).isFalse;
+  });
+  test('operator <=(DecimalIntl other)', () {
+    expectThat(decIntl('1') <= decIntl('1')).isTrue;
+    expectThat(decIntl('1') <= decIntl('1.0')).isTrue;
+    expectThat(decIntl('1') <= decIntl('1.1')).isTrue;
+    expectThat(decIntl('1') <= decIntl('0.9')).isFalse;
+  });
+  test('operator >(DecimalIntl other)', () {
+    expectThat(decIntl('1') > decIntl('1')).isFalse;
+    expectThat(decIntl('1') > decIntl('1.0')).isFalse;
+    expectThat(decIntl('1') > decIntl('1.1')).isFalse;
+    expectThat(decIntl('1') > decIntl('0.9')).isTrue;
+  });
+  test('operator >=(DecimalIntl other)', () {
+    expectThat(decIntl('1') >= decIntl('1')).isTrue;
+    expectThat(decIntl('1') >= decIntl('1.0')).isTrue;
+    expectThat(decIntl('1') >= decIntl('1.1')).isFalse;
+    expectThat(decIntl('1') >= decIntl('0.9')).isTrue;
   });
 }


### PR DESCRIPTION
Hi, I introduced logical operators `<`, `<=`, `>`, `>=` to `DecimalIntl` to support the `intl` package's recent update, `0.18.0`. 

It actually needed only `<` operator, but I decided to add all of them, just in case. 

The new `intl` package introduced some changes that broke the `NumberFormat.compactCurrency` as they now require the logical operator `<`. You can check it [here](https://github.com/dart-lang/i18n/blob/main/pkgs/intl/lib/src/intl/compact_number_format.dart#L474). 

In order to reproduce you can run the test `Number.compactCurrency output the correct results` on the current `intl` package version, 0.17.0.

This will help to support the latest Flutter versions `> 3.10.0`.

Looking forward to getting it merged. 

Thanks!


