### PR TITLE
Add `Decimal` prefix to extensions

### DIFF
--- a/lib/decimal.dart
+++ b/lib/decimal.dart
@@ -466,13 +466,13 @@ extension RationalExt on Rational {
 }
 
 /// Extensions on [BigInt].
-extension BigIntExt on BigInt {
+extension DecimalBigIntExt on BigInt {
   /// This [BigInt] as a [Decimal].
   Decimal toDecimal() => Decimal.fromBigInt(this);
 }
 
 /// Extensions on [int].
-extension IntExt on int {
+extension DecimalIntExt on int {
   /// This [int] as a [Decimal].
   Decimal toDecimal() => Decimal.fromInt(this);
 }


### PR DESCRIPTION
When I was trying to import `package:decimal` and `package:rational` simultaneously, the analyzer complained that they had a conflicting set of extensions.

```log
The name 'BigIntExt' is defined in the libraries 'package:decimal/decimal.dart' and 'package:rational/rational.dart'.
```

P.S. I would not expect the change to be a breaking change.