### PR TITLE
feat: default precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.3.0 (2025-09-11)
+
+- Add `Decimal.defaultPrecision` and `Decimal.defaultScaleOnInfinitePrecision` to set the default precision and scale on infinite precision rationals when converting to `Decimal`.
+
 # 3.2.4 (2025-06-22)
 
 - Fix issue with scale of zero causing problem in addition/substraction with zero.

--- a/README.md
+++ b/README.md
@@ -78,5 +78,46 @@ var currencyFormatter = DecimalFormatter(NumberFormat.simpleCurrency(name: 'USD'
 currencyFormatter.parse('\$3.14'); // => 3.14
 ```
 
+## Default precision for infinite-precision rationals
+
+When a computation results in a non-terminating rational (for example `1/3`),
+converting it back to a `Decimal` requires choosing how many fractional digits
+to keep. By default, calling `toDecimal()` on such rationals throws to avoid
+silent precision choices.
+
+You can set a global default number of fractional digits that will be used
+app-wide whenever the scale is not explicitly provided:
+
+```dart
+// Set once at app start
+Decimal.defaultScaleOnInfinitePrecision = 20; // preferred
+// or the short alias:
+Decimal.defaultPrecision = 20;
+
+final one = Decimal.parse('1');
+final three = Decimal.parse('3');
+
+// Division returns a Rational; with the default set, toDecimal() uses it:
+final approx = (one / three).toDecimal();
+print(approx); // 0.33333333333333333333 (20 fractional digits)
+
+// You can still override per call:
+final approx4 = (one / three).toDecimal(scaleOnInfinitePrecision: 4);
+print(approx4); // 0.3333
+
+// Resetting to null restores the original throwing behavior
+Decimal.defaultScaleOnInfinitePrecision = null;
+// (one / three).toDecimal(); // throws AssertionError
+```
+
+Where this default is used (from `lib/decimal.dart`):
+
+- When calling `Rational.toDecimal()` via the extension on `Rational` and the
+  rational does not have finite precision, if you do not pass
+  `scaleOnInfinitePrecision`, the library will use
+  `Decimal.defaultScaleOnInfinitePrecision` (or `Decimal.defaultPrecision`) if
+  set; otherwise it throws. All other internal conversions in `decimal.dart`
+  operate on finite-precision rationals and do not consult this default.
+
 ## License
 Apache 2.0

--- a/lib/decimal.dart
+++ b/lib/decimal.dart
@@ -28,6 +28,44 @@ final _r10 = Rational.fromInt(10);
 class Decimal implements Comparable<Decimal> {
   Decimal._(this._value, this._scale);
 
+  /// Global configuration: default number of fractional digits to use when
+  /// converting a [Rational] without finite precision (e.g. 1/3) to a
+  /// [Decimal] when the scale is not explicitly provided.
+  ///
+  /// If null (the default), calling `Rational.toDecimal()` without providing
+  /// `scaleOnInfinitePrecision` will throw an [AssertionError] for rationals
+  /// without finite precision, preserving the previous behavior.
+  ///
+  /// This default is only consulted by `RationalExt.toDecimal()` when
+  /// `hasFinitePrecision` is false and no explicit `scaleOnInfinitePrecision`
+  /// is provided. All internal uses in this file that convert rationals back
+  /// to decimals operate on powers of 10 (finite precision) and therefore do
+  /// not use this default.
+  static int? _defaultScaleOnInfinitePrecision;
+
+  /// The default number of fractional digits used for infinite-precision
+  /// rationals when converting to [Decimal].
+  static int? get defaultScaleOnInfinitePrecision =>
+      _defaultScaleOnInfinitePrecision;
+
+  /// Sets the default number of fractional digits used for infinite-precision
+  /// rationals when converting to [Decimal].
+  static set defaultScaleOnInfinitePrecision(int? value) {
+    if (value != null && value < 0) {
+      throw ArgumentError.value(
+          value, 'defaultScaleOnInfinitePrecision', 'must be >= 0 or null');
+    }
+    _defaultScaleOnInfinitePrecision = value;
+  }
+
+  /// Alias for [defaultScaleOnInfinitePrecision] with a shorter name that
+  /// avoids collision with the instance getter [precision].
+  static int? get defaultPrecision => _defaultScaleOnInfinitePrecision;
+
+  /// See [defaultPrecision] getter for details.
+  static set defaultPrecision(int? value) =>
+      defaultScaleOnInfinitePrecision = value;
+
   /// Create a new [Decimal] from a [BigInt].
   factory Decimal.fromBigInt(BigInt value) => Decimal._(value, 0);
 
@@ -412,7 +450,13 @@ extension RationalExt on Rational {
   /// to convert `this` to a [Decimal] representation. By default [toBigInt]
   /// use [Rational.truncate] to limit the number of digit.
   ///
-  /// Note that the returned decimal will not be exactly equal to `this`.
+  /// If [hasFinitePrecision] is `false` and [scaleOnInfinitePrecision] is not
+  /// provided, the global [Decimal.defaultScaleOnInfinitePrecision] (or its
+  /// alias [Decimal.defaultPrecision]) will be used when set; otherwise this
+  /// method throws an [AssertionError] to avoid silent precision loss.
+  ///
+  /// Note that the returned decimal will not be exactly equal to `this` when
+  /// a finite scale is used.
   Decimal toDecimal({
     int? scaleOnInfinitePrecision,
     BigInt Function(Rational)? toBigInt,
@@ -421,6 +465,7 @@ extension RationalExt on Rational {
       var scale = _scale;
       return Decimal._((this * Rational(_i10.pow(scale))).toBigInt(), scale);
     }
+    scaleOnInfinitePrecision ??= Decimal.defaultScaleOnInfinitePrecision;
     if (scaleOnInfinitePrecision == null) {
       throw AssertionError(
           'scaleOnInfinitePrecision is required for rationale without finite precision');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: decimal
-version: 3.2.4
+version: 3.3.0
 description: >
   The decimal package allows you to deal with decimal numbers without losing
   precision.

--- a/test/decimal_test.dart
+++ b/test/decimal_test.dart
@@ -448,4 +448,39 @@ void main() {
       toBigInt: (v) => v.round(),
     )).equals(dec('0.7'));
   });
+
+  group('Global default scale for infinite precision rationals', () {
+    test('uses Decimal.defaultPrecision when not provided explicitly', () {
+      final previous = Decimal.defaultPrecision;
+      try {
+        Decimal.defaultPrecision = 2;
+        expectThat(Rational.fromInt(1, 3).toDecimal()).equals(dec('0.33'));
+        Decimal.defaultPrecision = 1;
+        expectThat(Rational.fromInt(2, 3).toDecimal()).equals(dec('0.6'));
+      } finally {
+        Decimal.defaultPrecision = previous;
+      }
+    });
+
+    test('rejects negative values', () {
+      final previous = Decimal.defaultPrecision;
+      try {
+        expectThat(() => Decimal.defaultPrecision = -1)
+            .throwsA<ArgumentError>();
+      } finally {
+        Decimal.defaultPrecision = previous;
+      }
+    });
+
+    test('null restores original behavior (throws on infinite precision)', () {
+      final previous = Decimal.defaultPrecision;
+      try {
+        Decimal.defaultPrecision = null;
+        expectThat(() => Rational.fromInt(1, 3).toDecimal())
+            .throwsA<AssertionError>();
+      } finally {
+        Decimal.defaultPrecision = previous;
+      }
+    });
+  });
 }


### PR DESCRIPTION
This pull request introduces a new global configuration for controlling the default precision when converting infinite-precision rationals (such as 1/3) to `Decimal`. This allows users to specify how many fractional digits should be kept during such conversions, improving usability and preventing unexpected exceptions. The update includes new API fields, documentation, and tests for this feature.

**New global configuration for infinite-precision rational conversion:**

* Added static fields `Decimal.defaultScaleOnInfinitePrecision` and its alias `Decimal.defaultPrecision` to control the default number of fractional digits when converting infinite-precision rationals to `Decimal`. If unset, the previous throwing behavior is preserved.
* Updated `RationalExt.toDecimal()` to use the new global default if `scaleOnInfinitePrecision` is not provided for infinite-precision rationals. Throws an `AssertionError` if neither is set. [[1]](diffhunk://#diff-f1c57ad606ae249192fad6d5c8d3837d2af89a04d1a03a8b6067c51f1bc1671dL415-R459) [[2]](diffhunk://#diff-f1c57ad606ae249192fad6d5c8d3837d2af89a04d1a03a8b6067c51f1bc1671dR468)

**Documentation and usage examples:**

* Added a new section to the `README.md` explaining the new default precision setting, with code samples and clarification of its behavior and scope.
* Updated `CHANGELOG.md` to document the new feature in version 3.3.0.

**Testing and versioning:**

* Added tests to ensure the new global default works as intended, including checks for correct behavior, error handling, and restoration of the original behavior when set to null.
* Bumped the package version to 3.3.0 in `pubspec.yaml`.