### PR TITLE
Fix toStringAsPrecision emitting an extra digit on power-of-10 carry

### DIFF
--- a/lib/decimal.dart
+++ b/lib/decimal.dart
@@ -370,6 +370,12 @@ class Decimal implements Comparable<Decimal> {
       shift = (shift / ten).toDecimal();
     }
     final value = ((this * shift).round() / shift).toDecimal();
+    // Rounding can carry into a new power of 10 (e.g. `9.99` with precision 2
+    // rounds to `10`). That adds an integer digit, so one fewer fractional
+    // digit is needed to keep exactly [precision] significant digits.
+    if (value.abs() * shift >= limit) {
+      pad--;
+    }
     return pad <= 0 ? value.toString() : value.toStringAsFixed(pad);
   }
 

--- a/test/decimal_test.dart
+++ b/test/decimal_test.dart
@@ -368,6 +368,12 @@ void main() {
     expectThat(dec('1.235').toStringAsPrecision(1)).equals('1');
     expectThat(dec('1.235').toStringAsPrecision(5)).equals('1.2350');
     expectThat(dec('1.235').toStringAsPrecision(10)).equals('1.235000000');
+    // Rounding that carries into a new power of 10 must keep exactly
+    // `precision` significant digits (no extra trailing digit).
+    expectThat(dec('9.99').toStringAsPrecision(2)).equals('10');
+    expectThat(dec('9.96').toStringAsPrecision(2)).equals('10');
+    expectThat(dec('999.999').toStringAsPrecision(4)).equals('1000');
+    expectThat(dec('0.9999').toStringAsPrecision(3)).equals('1.00');
   });
   test('issue #13', () {
     expectThat(Decimal.parse('21.962962546543768').toString())


### PR DESCRIPTION
## Problem

When rounding to the requested precision carries into a new power of 10, `toStringAsPrecision` emits one **extra** significant digit:

```dart
Decimal.parse('9.99').toStringAsPrecision(2);    // '10.0'   (expected '10')
Decimal.parse('9.96').toStringAsPrecision(2);    // '10.0'   (expected '10')
Decimal.parse('999.999').toStringAsPrecision(4); // '1000.0' (expected '1000')
Decimal.parse('0.9999').toStringAsPrecision(3);  // '1.000'  (expected '1.00')
```

The number of fractional digits (`pad`) is derived from the *pre-rounded* magnitude. When rounding bumps the value across a power of 10 (e.g. `9.99 -> 10`), it gains an integer digit, so `pad` ends up one too high and a spurious trailing digit is shown. This is the same class of edge case as #74 (normalisation after rounding to 10).

## Fix

After rounding, detect the carry (the rounded value reaches the precision limit) and decrement `pad` by one, so exactly `precision` significant digits are kept. Non-carry cases are unaffected.

## Tests

Added carry cases to the `toStringAsPrecision` test. They fail on `master` and pass with this change; the full suite (`dart test`) passes.

Happy to add a CHANGELOG entry if you'd like one.